### PR TITLE
Head-to-head implemention

### DIFF
--- a/R/2_dynamic_ui.R
+++ b/R/2_dynamic_ui.R
@@ -252,22 +252,45 @@ make_INT_timing_by_COH_ui <- function(COH_id, input){
 
 # Create cohort customization tabs ---------------------------------------------
 make_COH_customization_tab_ui <- function(COH_id, input){
-  # Setup lists of interventions for the bucket_list
-  # First initialization just uses
+  # Setup bucket_list ==========================================================
+  # First initialization just uses all interventions as included
   if(is.null(input[[paste0("COH_bucket_group_", COH_id)]])){
-    included_INT <- lapply(1:input$n_INT, 
-                           function(x){input[[paste0("INT_name_",x)]]})
-    names(included_INT) <- 1:input$n_INT
-    excluded_INT <- NULL
+    incl_INT_names <- lapply(1:input$n_INT, 
+                             function(x){input[[paste0("INT_name_",x)]]})
+    names(incl_INT_names) <- 1:input$n_INT
+    excl_INT_names <- NULL
   } else {
-    included_INT <- lapply(input[[paste0("COH_INT_incl_order_", COH_id)]], 
-                           function(x){input[[paste0("INT_name_",x)]]})
-    names(included_INT) <- input[[paste0("COH_INT_incl_order_", COH_id)]]
-    excluded_INT <- lapply(input[[paste0("COH_INT_excl_order_", COH_id)]], 
-                           function(x){input[[paste0("INT_name_",x)]]})
-    names(excluded_INT) <- input[[paste0("COH_INT_excl_order_", COH_id)]]
+  # All subsequent runs need to check to see if the intervention number has
+  #   changed to see if the interventions are still eligible and if interventions
+  #   need to be added
+    # --- Excluded interventions ---
+    existing_excl_INT <- input[[paste0("COH_INT_excl_order_", COH_id)]]
+    excl_INT <- existing_excl_INT[existing_excl_INT %in% 1:input$n_INT]
+    
+    # Get names in format required by bucket
+    excl_INT_names <- lapply(excl_INT,
+                             function(x){input[[paste0("INT_name_",x)]]})
+    names(excl_INT_names) <- excl_INT
+    # --- Included interventions ---
+    existing_incl_INT <- input[[paste0("COH_INT_incl_order_", COH_id)]]
+    incl_INT <- existing_incl_INT[existing_incl_INT %in% 1:input$n_INT]
+    
+    # Add missing interventions to the end of included
+    # if(length(excl_INT) + length(incl_INT) == input$n_INT){
+    #   missing_INTs <- NULL
+    # } else {
+    #   browser()
+    #   missing_INTs <- 1:input$n_INT[!(1:input$n_INT %in% c(excl_INT, incl_INT))] 
+    # }
+    missing_INTs <- (1:input$n_INT)[!(1:input$n_INT %in% c(excl_INT, incl_INT))] 
+    incl_INT <- c(incl_INT, missing_INTs)
+    
+    # Get names in format required by bucket
+    incl_INT_names <- lapply(incl_INT, 
+                             function(x){input[[paste0("INT_name_",x)]]})
+    names(incl_INT_names) <- incl_INT
   }
-  
+
   # Create tabPanel
   tabPanel(
     title = COH_id,
@@ -286,12 +309,12 @@ make_COH_customization_tab_ui <- function(COH_id, input){
       orientation = "vertical",
       add_rank_list(
         text = NULL,
-        labels = included_INT,
+        labels = incl_INT_names,
         input_id = paste0("COH_INT_incl_order_", COH_id)
       ),
       add_rank_list(
         text = "Excluded from this cohort",
-        labels = excluded_INT,
+        labels = excl_INT_names,
         input_id = paste0("COH_INT_excl_order_", COH_id)
       )
     ),

--- a/R/2_dynamic_ui.R
+++ b/R/2_dynamic_ui.R
@@ -7,14 +7,36 @@
 # Default value in the box is the current value if initialized, otherwise blank
 # Blank name values need to be handled by other functions
 make_INT_name_ui <- function(input){
-  lapply(1:input$n_INT,
-         function(i){
-           textInput(
-             inputId = paste0("INT_name_", i),
-             label = paste0("Name of intervention ", i),
-             value = ifelse(is.null(input[[paste0("INT_name_", i)]]),
-                            "",
-                            input[[paste0("INT_name_", i)]]))})
+  c(lapply(
+    1:input$n_INT,
+    function(i){
+      row <- list(
+        tags$u(strong(paste0("Name of intervention ", i))),
+        textInput(
+          inputId = paste0("INT_name_", i),
+          label = NULL,
+          value = ifelse(is.null(input[[paste0("INT_name_", i)]]),
+                         "",
+                         input[[paste0("INT_name_", i)]])))
+      if(!is.null(input$INT_h2h) && input$INT_h2h){
+        row <- append(
+          row, 
+          list(textInput(
+            inputId = paste0("INT_", i, "_h2h_name"),
+            label = "Versus",
+            value = ifelse(is.null(input[[paste0("INT_", i, "_h2h_name")]]),
+                           "",
+                           input[[paste0("INT_", i, "_h2h_name")]]))))
+      }
+      return(row)
+    }),
+    list(checkboxInput(
+      inputId = "INT_h2h",
+      label = "Allow Head-to-Head Interventions?",
+      value = ifelse(is.null(input$INT_h2h),
+                     FALSE,
+                     input$INT_h2h)))
+  )
 }
 
 # Create intervention timing tabs -----------------------------------------------

--- a/R/6_generate_study.R
+++ b/R/6_generate_study.R
@@ -51,7 +51,7 @@ custom_study_config <- function(input){
   #   for the UI to be loaded. Checks for presence of input buckets and timing
   for(i in 1:input$n_COH){
     if(is.null(input[[paste0("COH_INT_incl_order_", i)]]) || 
-       is.null(input[[paste0("INT_start_max_COH_", i)]])){
+       is.null(input[[paste0("INT_length_",input$n_INT,"_COH_",i)]])){
       return(NULL)
     }
     # If this cohort has no interventions, continue to the next cohort

--- a/R/6_generate_study.R
+++ b/R/6_generate_study.R
@@ -66,11 +66,13 @@ custom_study_config <- function(input){
   config <- config %>%
     rowwise() %>%
     mutate(INT_length = 
-             if_else(is.na(input[[paste0("INT_length_",INT,"_COH_",COH)]]),
+             if_else(is.null(input[[paste0("INT_length_",INT,"_COH_",COH)]]) ||
+                       is.na(input[[paste0("INT_length_",INT,"_COH_",COH)]]),
                      input[[paste0("INT_length_",INT)]],
                      input[[paste0("INT_length_",INT,"_COH_",COH)]]),
            INT_gap = 
-             if_else(is.na(input[[paste0("INT_gap_",INT,"_COH_",COH)]]),
+             if_else(is.null(input[[paste0("INT_gap_",INT,"_COH_",COH)]]) ||
+                       is.na(input[[paste0("INT_gap_",INT,"_COH_",COH)]]),
                      input[[paste0("INT_gap_",INT)]],
                      input[[paste0("INT_gap_",INT,"_COH_",COH)]]),
            INT_offset = input$INT_offset,

--- a/R/6_generate_study.R
+++ b/R/6_generate_study.R
@@ -12,13 +12,17 @@ basic_study_config <- function(input){
                INT_length = sapply(
                  1:input$n_INT, 
                  function(i){
-                   input[[paste0("INT_length_",i)]]
+                   ifelse(is.null(input[[paste0("INT_length_",i)]]),
+                          default$study$INT_length,
+                          input[[paste0("INT_length_",i)]])
                  }),
                # Need to iterate through all intervention gaps
                INT_gap = sapply(
                  1:input$n_INT, 
                  function(i){
-                   input[[paste0("INT_gap_",i)]]
+                   ifelse(is.null(input[[paste0("INT_gap_",i)]]),
+                          default$study$INT_gap,
+                          input[[paste0("INT_gap_",i)]])
                  }),
                # Offset has special case where if it is completely uninitialized,
                #   it needs to be 0/NA so that a phantom study is not created.

--- a/R/6_generate_study.R
+++ b/R/6_generate_study.R
@@ -7,7 +7,7 @@
 #   configuration for each intervention
 basic_study_config <- function(input){
   cross_join(data.frame(COH = 1:input$n_COH),
-             data.frame(INT = 1:input$n_INT,
+             data.frame(INT = as.character(1:input$n_INT),
                # Need to iterate through all intervention lengths
                INT_length = sapply(
                  1:input$n_INT, 

--- a/R/8_make_plot.R
+++ b/R/8_make_plot.R
@@ -8,19 +8,54 @@ make_plot <- function(study, args=list()){
   default_args = list(
     COH_names = paste("Cohort", 1:max(study$COH)),
     INT_names = paste("Intervention", 1:max(study$INT)),
-    time_units = "Time"
+    time_units = "Time",
+    h2h = FALSE
   )
   
   # Take input and update defaults
   viz_args = modifyList(default_args, args)
   
+  # Add INT names into study (in order)
+  study_named <- study %>%
+    left_join(data.frame(INT = as.character(1:max(study$INT)),
+                         INT_name = viz_args$INT_names),
+              by=join_by("INT")) %>%
+    arrange(COH, INT_start) %>%
+    mutate(is_h2h = F)
+  
+  # Get h2h segments
+  if(viz_args$h2h){
+    all_INTs <- study_named %>%
+      left_join(viz_args$h2h_df, by=join_by(INT)) %>%
+      filter(!is.na(h2h_name)) %>%
+      mutate(INT_name = h2h_name) %>%
+      bind_rows(study_named) %>%
+      arrange(COH, INT_start, !is.na(h2h_name))
+    
+    unique_INTs <- unique(all_INTs$INT_name)
+
+    study_named <- all_INTs %>%
+      group_by(COH, INT_start) %>%
+      mutate(is_h2h = n()>1) %>%
+      ungroup()
+  } else {
+    h2h_INTs <- NULL
+    unique_INTs <- unique(study_named$INT_name)
+  }
+
   # Create plot
-  ggplot(data = study, aes(y=factor(COH), color=factor(INT))) +
-    geom_segment(aes(x=INT_start, xend=INT_end), linewidth=12) +
-    scale_color_brewer(name=NULL, 
-                       palette="Set1",
-                       breaks = 1:length(viz_args$INT_names),
-                       labels = viz_args$INT_names) +
+  ggplot(mapping=aes(x=INT_start, xend=INT_end, y=factor(COH), group=factor(COH),
+                     color=factor(INT_name))) +
+    # TODO: Switch to rectangles to allow for more control over drawing?
+    # Draw full lines
+    geom_segment(data=filter(study_named, !is_h2h), linewidth=12, key_glyph = "rect") +
+    # Draw half lines for head-to-heads
+    geom_segment(data=filter(study_named, is_h2h), linewidth=6, 
+                 position = "dodge", 
+                 key_glyph = "rect") +
+    scale_color_brewer(name = NULL, 
+                       palette = "Set1",
+                       breaks = unique_INTs) +
     scale_x_continuous(viz_args$time_units, breaks=scales::breaks_pretty()) +
     scale_y_discrete("Cohort", 
                      breaks = 1:length(viz_args$COH_names), 

--- a/R/8_make_plot.R
+++ b/R/8_make_plot.R
@@ -14,11 +14,11 @@ make_plot <- function(study, args=list()){
   )
   # Take input and update defaults
   viz_args = modifyList(default_args, args)
-  
+
   # Add names and order study data frame =======================================
   # Add INT names, set standard column width, and arrange
   study_named <- study %>%
-    left_join(data.frame(INT = as.character(1:max(study$INT)),
+    left_join(data.frame(INT = as.character(1:length(viz_args$INT_names)),
                          INT_name = viz_args$INT_names),
               by=join_by("INT")) %>%
     mutate(col_min = COH-0.1,

--- a/server.R
+++ b/server.R
@@ -52,8 +52,9 @@ server <- function(input, output){
   ## --- Intervention Naming ---
   ## Creates a number of text inputs equal to the number of interventions
   output$INT_names <- renderUI({
-    # Isolated values will only be recalculated if the tab changes
+    # Isolated values will only be recalculated if the number of INT or tab changes
     input$input_tabs
+    input$n_INT
     # If h2h button has been initialized, redraw when it is updated
     if(!is.null(input$INT_h2h)){
       input$INT_h2h
@@ -66,11 +67,14 @@ server <- function(input, output){
   ## --- Intervention Timing ---
   ## Creates a number of duration inputs equal to the number of interventions
   output$INT_timings <- renderUI({
-    # Isolated values will only be recalculated if the tab or number changes
-    input$input_tabs
+    # Check if it should be drawn at all
     if(is.na(input$n_INT) || input$n_INT<1){
       return(helpText("Number of interventions is invalid"))
     }
+    # Isolated values will only be recalculated if the tab or number changes
+    input$input_tabs
+    input$n_INT
+    # Generate intervention timings
     c(isolate(make_INT_timing_ui(input)),
       list(
         numericInput(

--- a/server.R
+++ b/server.R
@@ -53,8 +53,8 @@ server <- function(input, output){
   ## Creates a number of text inputs equal to the number of interventions
   output$INT_names <- renderUI({
     # Isolated values will only be recalculated if the number of INT or tab changes
-    input$input_tabs
     input$n_INT
+    input$input_tabs
     # If h2h button has been initialized, redraw when it is updated
     if(!is.null(input$INT_h2h)){
       input$INT_h2h
@@ -160,14 +160,16 @@ server <- function(input, output){
     ## --- Conditional add ---
     # Add cohort names if initialized
     if(input$advanced_COH) {
-      option_list <- append(option_list,
-                            list(COH_names = sapply(
-                              1:input$n_COH, 
-                              function(i){
-                                ifelse(input[[paste0("COH_name_", i)]] == "",
-                                       paste0("Cohort ", i),
-                                       input[[paste0("COH_name_", i)]])
-                              })))
+      option_list <- append(
+        option_list,
+        list(COH_names = sapply(
+          1:input$n_COH, 
+          function(i){
+            ifelse(is.null(input[[paste0("COH_name_", i)]]) || 
+                     input[[paste0("COH_name_", i)]] == "",
+                   paste0("Cohort ", i),
+                   input[[paste0("COH_name_", i)]])
+      })))
     }
     # Add head to head configuration if selected
     if(!is.null(input$INT_h2h) && input$INT_h2h){
@@ -191,14 +193,16 @@ server <- function(input, output){
     }
     ## --- Always add ---
     # Add intervention names
-    option_list <- append(option_list,
-                          list(INT_names = sapply(
-                            1:input$n_INT,
-                            function(i){
-                              ifelse(input[[paste0("INT_name_", i)]] == "",
-                                     paste0("Intervention ", i),
-                                     input[[paste0("INT_name_", i)]])
-                            })))
+    option_list <- append(
+      option_list,
+      list(INT_names = sapply(
+        1:input$n_INT,
+        function(i){
+          ifelse(is.null(input[[paste0("INT_name_", i)]]) ||
+                   input[[paste0("INT_name_", i)]] == "",
+                 paste0("Intervention ", i),
+                 input[[paste0("INT_name_", i)]])
+    })))
     # Add timing unit
     if(input$time_units!="") {
       option_list <- append(option_list,
@@ -217,7 +221,7 @@ server <- function(input, output){
     make_plot(study(), viz_options())
   })
   
-  # Optional Testing Outputs ===================================================
+  # Debugging Outputs ===================================================
   # Returns a text of all input values
   output$input_list <- renderText({
     # Check if this is wanted


### PR DESCRIPTION
**Implement head-to-head specification**

- Completes #4. User can define head-to-head trials on the intervention naming screen. These interventions then appear striped on the plot.
- Fixes #15. Buckets now update to remove interventions that are greater than the number of interventions and add new interventions to the end of the inclusion stack.